### PR TITLE
Support data-linking directly to class attribute

### DIFF
--- a/jquery.views.js
+++ b/jquery.views.js
@@ -123,6 +123,14 @@ function propertyChangeHandler( ev, eventArgs ) {
 				if ( changed = $target.css( css ) !== sourceValue ) {
 					$target.css( css, sourceValue );
 				}
+			} else if ( css = attr.indexOf( "class-") === 0 && attr.substr( 6 )) {
+				if ( changed = (sourceValue && true) !== $target.hasClass( css ) ) {
+					if (sourceValue) {
+						$target.addClass( css );
+					} else {
+						$target.removeClass( css );
+					}
+				}
 			} else {
 				setter = fnSetters[ attr ];
 				if ( setter ) {


### PR DESCRIPTION
Hi Boris, never done this before so hope it's the right process. I found it frustrating that I couldn't control the presence of a css class on an element from my view model, so I modified the jsviews code to allow this.

class on an element to be controlled by a boolean (or "truthy") source
value, with syntax like:

`data-getfrom="class-myclass: [isMyClass]"`
