### PR TITLE
Ask an observable which html elements it belongs to

### DIFF
--- a/jquery.observable.js
+++ b/jquery.observable.js
@@ -92,6 +92,20 @@
 
 		_trigger: function( target, eventArgs ) {
 			$( target ).triggerHandler( "propertyChange", eventArgs );
+		},
+
+		nodesFor: function( path ) {
+			var object = this._data,
+				leaf = getLeafObject( object, path );
+
+			path = leaf[1];
+			leaf = leaf[0];
+
+			var links = [],
+			    eventArgs = { path: path, back: function(link){ link.tgt && links.push(link.tgt) } }
+
+			$(leaf).triggerHandler("pingme", eventArgs); // aren't we lucky people: this is a synchronous call
+			return $(links);
 		}
 	};
 

--- a/jquery.observable.js
+++ b/jquery.observable.js
@@ -215,6 +215,24 @@
 
 		_trigger: function( eventArgs ) {
 			$([ this._data ]).triggerHandler( "arrayChange", eventArgs );
+		},
+
+		nodesFor: function( index ){
+			index && validateIndex(index);
+
+			var links = [],
+				eventArgs = { index: index, back: function(view){ 
+					if (index >= 0){
+						view && view.views && view.views[index] && links.push.apply(links, view.views[index].nodes) 
+					} else {
+						view && view.views && $.each(view.views, function(i, view){
+							links.push.apply(links, view.nodes);
+						})
+					}
+				} };
+
+			$([ this._data ]).trigger( "pingme", eventArgs );
+			return $(links);
 		}
 	};
 })(jQuery);

--- a/jquery.observable.js
+++ b/jquery.observable.js
@@ -231,7 +231,7 @@
 					}
 				} };
 
-			$([ this._data ]).trigger( "pingme", eventArgs );
+			$([ this._data ]).triggerHandler( "pingme", eventArgs );
 			return $(links);
 		}
 	};

--- a/jquery.views.js
+++ b/jquery.views.js
@@ -142,6 +142,10 @@ this.jQuery && jQuery.link || (function(global, undefined) {
 		//				context.afterChange.call( link, ev, eventArgs );
 		//			}
 
+		if (ev && ev.type == "pingme" && eventArgs && ev.data === eventArgs.path){
+			eventArgs.back && eventArgs.back(this, eventArgs.path);
+			return target;
+		}
 		if ((!beforeChange || !(eventArgs && beforeChange.call(this, ev, eventArgs) === FALSE))
 		// If data changed, the ev.data is set to be the path. Use that to filter the handler action...
 		&& !(eventArgs && ev.data !== eventArgs.path))
@@ -403,6 +407,8 @@ this.jQuery && jQuery.link || (function(global, undefined) {
 			} else {
 				boundParams.push(object);
 				$(object).on(propertyChangeStr, NULL, leafToken, handler);
+
+				$(object).on('pingme', NULL, leafToken, handler);
 			}
 			return object;
 		});

--- a/jquery.views.js
+++ b/jquery.views.js
@@ -211,6 +211,10 @@ this.jQuery && jQuery.link || (function(global, undefined) {
 		var context = this.ctx,
 			beforeChange = context.beforeChange;
 
+		if (ev.type === "pingme"){
+			eventArgs.back && eventArgs.back( this );
+			return
+		}
 		if (!beforeChange || beforeChange.call(this, ev, eventArgs) !== FALSE) {
 			this._onDataChanged(eventArgs);
 			if (context.afterChange) {
@@ -237,6 +241,7 @@ this.jQuery && jQuery.link || (function(global, undefined) {
 					arrayChangeHandler.apply(view, arguments);
 				};
 				$([data]).on(arrayChangeStr, handler);
+				$([data]).on("pingme", handler);
 				view._onArrayChange = [handler, data];
 			}
 		}


### PR DESCRIPTION
Similiar to my #70, and just as a concept

```
$.observable(data.contact).nodesFor('name').first().focus()
```
See it: http://jsbin.com/uzuwar/4/edit

nodesFor answers some selected jquery nodes you can use immediately. 

I had the case that in a click handler I lost my `this` because I had to do a `view.refresh`. Now when that happens you're clearly lost in the jQuery world, because you don't have a `parent` nor a `closest`. I wanted to focus the first input element, this is how the hack came...