### PR TITLE
Fix issue #287

### DIFF
--- a/jsrender.js
+++ b/jsrender.js
@@ -577,7 +577,9 @@ informal pre V1.0 commit counter: 60 */
 			};
 
 		self.data = data;
-		self.tmpl = template,
+		self.tmpl = template && $extend({}, template);
+		if (template && template.links)
+			self.tmpl.links = {};
 		self.content = contentTmpl;
 		self.views = isArray ? [] : {};
 		self.parent = parentView;
@@ -989,6 +991,7 @@ informal pre V1.0 commit counter: 60 */
 					newView = swapContent
 						? parentView :
 						(key !== undefined && parentView) || new View(context, "array", parentView, data, tmpl, key, contentTmpl, onRender);
+					tmpl = newView.tmpl;
 					for (i = 0, l = data.length; i < l; i++) {
 						// Create a view for each data item.
 						dataItem = data[i];
@@ -1001,6 +1004,7 @@ informal pre V1.0 commit counter: 60 */
 					// "item", "array" and "data" views. A "data" view is from programmatic render(object) against a 'singleton'.
 					if (parentView || !tmpl.fn._nvw) {
 						newView = swapContent ? parentView : new View(context, tmplName || "data", parentView, data, tmpl, key, contentTmpl, onRender);
+						tmpl = newView.tmpl;
 						if (tag_ && !self.flow) {
 							newView.tag = self;
 						}

--- a/jsviews.js
+++ b/jsviews.js
@@ -576,7 +576,9 @@ informal pre V1.0 commit counter: 60 (Beta Candidate) */
 			};
 
 		self.data = data;
-		self.tmpl = template,
+		self.tmpl = template && $extend({}, template);
+		if (template && template.links)
+			self.tmpl.links = {};
 		self.content = contentTmpl;
 		self.views = isArray ? [] : {};
 		self.parent = parentView;
@@ -988,6 +990,7 @@ informal pre V1.0 commit counter: 60 (Beta Candidate) */
 					newView = swapContent
 						? parentView :
 						(key !== undefined && parentView) || new View(context, "array", parentView, data, tmpl, key, contentTmpl, onRender);
+					tmpl = newView.tmpl;
 					for (i = 0, l = data.length; i < l; i++) {
 						// Create a view for each data item.
 						dataItem = data[i];
@@ -1000,6 +1003,7 @@ informal pre V1.0 commit counter: 60 (Beta Candidate) */
 					// "item", "array" and "data" views. A "data" view is from programmatic render(object) against a 'singleton'.
 					if (parentView || !tmpl.fn._nvw) {
 						newView = swapContent ? parentView : new View(context, tmplName || "data", parentView, data, tmpl, key, contentTmpl, onRender);
+						tmpl = newView.tmpl;
 						if (tag_ && !self.flow) {
 							newView.tag = self;
 						}

--- a/test/unit-tests/tests-jsviews.js
+++ b/test/unit-tests/tests-jsviews.js
@@ -3183,6 +3183,74 @@ test("computed observables in two-way binding", function() {
 	// ................................ Reset ................................
 	$("#result").empty();
 })();
+
+(function() {
+	// =============================== Arrange ===============================
+	function Root(a){
+	    this._a = a;
+	    this.a = function() {
+	        if (!arguments.length)
+	            return this._a;
+	        else
+	            this._a = arguments[0];
+	    };
+	    this.a.set = true;
+	}
+
+	function A(b){
+	    this._b = b;
+	    this.b = function() {
+	        if (!arguments.length)
+	            return this._b;
+	        else
+	            this._b = arguments[0];
+	    };
+	    this.b.set = true;
+	}
+
+	var o1 = new Root(new A('one')),
+		o2 = new Root(new A('two'));
+
+	$.templates('field', '<input data-link="{:a().b() :}"><span data-link="{:a().b()}"></span>');
+
+	$("#result").html("<div id='one'></div><div id='two'><div>");
+
+	$.templates.field.link('#one', o1);
+	$.templates.field.link('#two', o2);
+
+	// ................................ Act ..................................
+	var res = $("#one input").val() + $("#one span").text();
+	res += "|" + $("#two input").val() + $("#two span").text();
+
+	$("#one input").val('onechange').change();
+
+	res += "|" + $("#one input").val() + $("#one span").text();
+	res += "|" + $("#two input").val() + $("#two span").text();
+
+	$("#two input").val('twochange').change();
+
+	res += "|" + $("#one input").val() + $("#one span").text();
+	res += "|" + $("#two input").val() + $("#two span").text();
+
+	$.observable(o1.a()).setProperty('b', 'oneupdate');
+
+	res += "|" + $("#one input").val() + $("#one span").text();
+	res += "|" + $("#two input").val() + $("#two span").text();
+
+	$.observable(o2.a()).setProperty('b', 'twoupdate');
+
+	res += "|" + $("#one input").val() + $("#one span").text();
+	res += "|" + $("#two input").val() + $("#two span").text();
+
+
+	// ............................... Assert .................................
+	equal(res,
+	"oneone|twotwo|onechangeonechange|twotwo|onechangeonechange|twochangetwochange|oneupdateoneupdate|twochangetwochange|oneupdateoneupdate|twoupdatetwoupdate",
+	'Single template linked to independent elements with same path using complex computed observables remain independent');
+
+	// ................................ Reset ................................
+	$("#result").empty();
+})();
 });
 
 module("API - data-bound tags");


### PR DESCRIPTION
Update such that each instantiation (view)  of a template has it's
own tmpl.links object so that computed observables stored in the
tmpl.links.dep array are specific to that particular view and
not shared across views.

Added test cases to cover this scenario.
